### PR TITLE
Enable s3 overlay connection

### DIFF
--- a/data_io/connection.py
+++ b/data_io/connection.py
@@ -850,6 +850,7 @@ connection_builder.register(('redshift',), RedshiftConnection)
 connection_builder.register(('oracle',), OracleConnection)
 connection_builder.register(('postgresql',), PostgresqlConnection)
 connection_builder.register(('s3a',), S3Connection)
+connection_builder.register(('s3',), S3Connection)
 
 def build_connection(url: str, *largs, **kwargs) -> BaseConnection:
     """

--- a/data_io/location.py
+++ b/data_io/location.py
@@ -98,7 +98,7 @@ class LocationBuilder(URLKeyBuilder):
         path = urlparse(url)
 
         #checking if port is empty
-        if((path.port == None) and (path.scheme != 's3a')):
+        if((path.port == None) and (path.scheme != 's3a')) and (path.scheme != 's3')):
             user = urlparse(url)
             user = user._replace(netloc=
             user.netloc + ':' + default_port[user.scheme])
@@ -152,6 +152,7 @@ location_builder.register(('redshift',), DatabaseLocation)
 location_builder.register(('oracle',), DatabaseLocation)
 location_builder.register(('postgresql',), DatabaseLocation)
 location_builder.register(('s3a',), Location)
+location_builder.register(('s3',), Location)
 
 
 def build_location(url, *largs, **kwargs):

--- a/data_io/location.py
+++ b/data_io/location.py
@@ -98,7 +98,7 @@ class LocationBuilder(URLKeyBuilder):
         path = urlparse(url)
 
         #checking if port is empty
-        if((path.port == None) and (path.scheme != 's3a')) and (path.scheme != 's3')):
+        if((path.port == None) and (path.scheme != 's3a') and (path.scheme != 's3')):
             user = urlparse(url)
             user = user._replace(netloc=
             user.netloc + ':' + default_port[user.scheme])

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(
     name='data_io',
     # Hard code for now
-    version='0.2.4',
+    version='0.2.5',
     description='Standardize data IO at Thermo Fisher',
     author='Christopher Bishop',
     author_email='chris.bishop@thermofisher.com',


### PR DESCRIPTION
This PR enhances `data_io` to recognize the `s3` schema and `s3a` in the URL when building a connection with AWS S3 buckets.

The key differences between `s3` and `s3a` are as follows:
- `s3` supports objects up to 5GB in size, while `s3a` supports objects up to 5TB.
- `s3a` offers higher performance due to its use of multi-part upload.
- `s3a` is the successor to `s3n` and `s3` .

For more details, refer to this [Stack Overflow discussion](https://stackoverflow.com/questions/33356041/technically-what-is-the-difference-between-s3n-s3a-and-s3).
