### PR TITLE
Fix username retrieval for Databricks Shared Cluster compatibility

### DIFF
--- a/data_io/connection.py
+++ b/data_io/connection.py
@@ -235,8 +235,8 @@ class ConnectionBuilder(URLKeyBuilder):
                 .getDbutils()
                 .notebook()
                 .getContext()
-                .tags()
-                .apply('user')
+                .userName()
+                .get()
                 # XXX Hack incoming
                 .split('@')
                 [0]


### PR DESCRIPTION
Problem
The existing tag-based username retrieval method fails on Databricks Shared Clusters due to security restrictions that prevent access to internal context APIs via dbutils.notebook.entry_point.getDbutils().notebook().getContext().tags(). 

Solution
Refactored username retrieval to use the userName() method instead, which is compatible with Shared Cluster security policies while maintaining backward compatibility with standard clusters.
Testing
Verified functionality across both cluster types:

✅ Shared Cluster mode
✅ No Isolation Cluster mode

Impact
This change ensures reliable username retrieval across all Databricks cluster configurations, preventing connection failures in Shared Cluster environments.