### PR TITLE
Bugfix: Fix schema-specific credential lookup bug for database connections

### DIFF
--- a/data_io/location.py
+++ b/data_io/location.py
@@ -138,8 +138,8 @@ class DatabaseLocation(Location):
         elif len(path_split) == 2:
             # db, table
             # Occurs with backends like Impala
-            self.db, self.table = path_split
-            self.schema = None
+            self.db, self.schema = path_split
+            self.table = None
 
         # Add another use case with just the database
         elif len(path_split) == 1:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(
     name='data_io',
     # Hard code for now
-    version='1.0.2',
+    version='1.0.3',
     description='Standardize data IO at Thermo Fisher',
     author='Christopher Bishop',
     author_email='chris.bishop@thermofisher.com',


### PR DESCRIPTION

# Summary

Fixes a bug that occurs when a user specifies a database schema. The system previously attempted to look up schema-specific credentials (username/password) for the same connection URL but a different database, causing connection issues.

# Details

Before this change, the affected condition was rarely triggered because users seldom specified table names without also specifying the database.

# Testing

Verified with lsgmo and lsgds instances. See validation notebook: .
https://tfs-edp.cloud.databricks.com/editor/notebooks/477153582878611?o=2841493856018718#command/8648625749973728